### PR TITLE
Avoid sudden container resizing by using aspect-ratio box for image

### DIFF
--- a/src/Poppy.js
+++ b/src/Poppy.js
@@ -123,6 +123,7 @@ export class Poppy {
       imageContainer.style.width = "100%";
       imageContainer.style.paddingTop = "150px";
       imageContainer.style.backgroundSize = "cover";
+      imageContainer.style.backgroundPosition = "center";
       imageContainer.style.backgroundImage = `url(${image})`;
 
       imageContainer.onerror = () => {

--- a/src/Poppy.js
+++ b/src/Poppy.js
@@ -119,12 +119,12 @@ export class Poppy {
     };
     const createCoverImage = image => {
       if (!image) return null;
-      const imageContainer = document.createElement("img");
+      const imageContainer = document.createElement("div");
       imageContainer.style.width = "100%";
-      imageContainer.style.maxHeight = "150px";
-      imageContainer.style.objectFit = "cover";
+      imageContainer.style.paddingTop = "150px";
+      imageContainer.style.backgroundSize = "cover";
+      imageContainer.style.backgroundImage = `url(${image})`;
 
-      imageContainer.src = image;
       imageContainer.onerror = () => {
         imageContainer.style.display = "none";
         console.warn("Poppy: Cover image cannot be found.");


### PR DESCRIPTION
Hi @apvarun! Love the simplicity of this project. Also, I found your code very clean and easy to read—very well done!

One thing I noticed is that the Poppy container height changes suddenly after the image is loaded, which is too jarring and distracting for me (and I presume other users as well).

As a potential solution, I've converted the `<img>` element into `<div>` with a [padding-based aspect-ratio](https://css-tricks.com/aspect-ratio-boxes/) so there's no sudden height reflow after the image loads.

There's [a proposal](https://github.com/WICG/intrinsicsize-attribute) for a native image aspect ratio (e.g. `<img intrinsicsize="400x300" style="width: 100%">`) in the works, but I suspect it will be a while before it lands in the browsers.

Let me know what you think!
