### PR TITLE
Preload image by adding Poppy to DOM on init

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -126,7 +126,7 @@
       }
     }
   </style>
-  <script src="./Poppy/Poppy.min.js"></script>
+  <script src="../dist/Poppy.js" async></script>
 </head>
 
 <body>
@@ -258,29 +258,31 @@
   </footer>
 
   <script>
+    let pop = new Poppy({
+      title: {
+        text: "Planning a travel?",
+        avatar: "https://randomuser.me/api/portraits/women/31.jpg",
+        color: "#4fc3f7"
+      },
+      content:
+        "<strong>Travel Tips:</strong><br />If you are not a regular traveller, here are some of the tips for travellers.",
+      cta: {
+        text: "Create Your Own Poppy",
+        url: "https://github.com/apvarun/poppyjs",
+        color: "#4fc3f7",
+        newtab: true,
+        onclick: () => {
+          console.log("CTA Clicked");
+        }
+      },
+      coverImage: "https://source.unsplash.com/tK-Ag9DkuZU/400x250",
+      position: "bottomLeft",
+    });
+
     function triggerPoppy() {
-      let pop = new Poppy({
-        title: {
-          text: "Planning a travel?",
-          avatar: "https://randomuser.me/api/portraits/women/31.jpg",
-          color: "#4fc3f7"
-        },
-        content:
-          "<strong>Travel Tips:</strong><br />If you are not a regular traveller, here are some of the tips for travellers.",
-        cta: {
-          text: "Create Your Own Poppy",
-          url: "https://github.com/apvarun/poppyjs",
-          color: "#4fc3f7",
-          newtab: true,
-          onclick: () => {
-            console.log("CTA Clicked");
-          }
-        },
-        coverImage: "https://source.unsplash.com/tK-Ag9DkuZU/400x250",
-        position: "bottomRight"
-      });
       pop.show();
     }
+
     document
       .querySelector(".initPoppy")
       .addEventListener("click", triggerPoppy);

--- a/src/Poppy.js
+++ b/src/Poppy.js
@@ -123,6 +123,7 @@ export class Poppy {
       imageContainer.style.width = "100%";
       imageContainer.style.paddingTop = "150px";
       imageContainer.style.backgroundSize = "cover";
+      imageContainer.style.backgroundPosition = "center";
       imageContainer.style.backgroundImage = `url(${image})`;
 
       imageContainer.onerror = () => {

--- a/src/Poppy.js
+++ b/src/Poppy.js
@@ -34,7 +34,12 @@ export class Poppy {
     };
     this.element = null;
   }
+
   show() {
+    this.element.style.transform = 'translateY(0)';
+  }
+
+  init() {
     const createContainer = position => {
       const container = document.createElement("div");
       container.style.maxWidth = "300px";
@@ -47,6 +52,9 @@ export class Poppy {
       container.style.backgroundColor = "#FFF";
       container.style.fontFamily =
         '-apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif';
+
+      container.style.transition = '1s all';
+      container.style.transform = 'translateY(calc(100% + 20px))';
       if (position === "topLeft") {
         container.style.top = "0";
         container.style.left = "0";
@@ -63,6 +71,7 @@ export class Poppy {
 
       return container;
     };
+
     const createPopup = options => {
       const title = createTitle(options.title);
       const image = createCoverImage(options.coverImage);
@@ -76,6 +85,7 @@ export class Poppy {
       components.forEach(component => fragment.appendChild(component));
       return fragment;
     };
+
     const createTitle = title => {
       if (!title.text) return null;
       const titleContainer = document.createElement("div");
@@ -108,6 +118,7 @@ export class Poppy {
       titleContainer.appendChild(createCloseIcon());
       return titleContainer;
     };
+
     const createContent = content => {
       if (!content) return null;
       const contentContainer = document.createElement("div");
@@ -117,6 +128,7 @@ export class Poppy {
       contentContainer.innerHTML = content;
       return contentContainer;
     };
+
     const createCoverImage = image => {
       if (!image) return null;
       const imageContainer = document.createElement("div");
@@ -132,6 +144,7 @@ export class Poppy {
       };
       return imageContainer;
     };
+
     const createCTA = cta => {
       if (!cta || !cta.text || !cta.url) return null;
       const contentContainer = document.createElement("a");
@@ -156,6 +169,7 @@ export class Poppy {
 
       return contentContainer;
     };
+
     const createCloseIcon = () => {
       // Close Icon
       const closeIcon = `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-x-square">
@@ -169,13 +183,14 @@ export class Poppy {
 
       closeIconContainer.addEventListener("click", () => {
         if (this.element) {
-          this.element.parentNode.removeChild(this.element);
+          this.close();
         }
       });
 
       // OnClick Handler
       return closeIconContainer;
     };
+
     const createFragmentContainer = () => {
       return document.createDocumentFragment();
     };
@@ -197,9 +212,16 @@ export class Poppy {
       }
     }, this.state.delay);
   }
+
   close() {
     if (this.element && this.element.parentNode) {
-      this.element.parentNode.removeChild(this.element);
+      this.element.style.transform = 'translateY(calc(100% + 20px))';
+
+      this.element.addEventListener('transitionend', function closeContainer(event) {
+        if (event.propertyName === "transform") {
+          this.parentNode.removeChild(this);
+        }
+      })
     }
   }
 }

--- a/src/Poppy.js
+++ b/src/Poppy.js
@@ -119,12 +119,12 @@ export class Poppy {
     };
     const createCoverImage = image => {
       if (!image) return null;
-      const imageContainer = document.createElement("img");
+      const imageContainer = document.createElement("div");
       imageContainer.style.width = "100%";
-      imageContainer.style.maxHeight = "150px";
-      imageContainer.style.objectFit = "cover";
+      imageContainer.style.paddingTop = "150px";
+      imageContainer.style.backgroundSize = "cover";
+      imageContainer.style.backgroundImage = `url(${image})`;
 
-      imageContainer.src = image;
       imageContainer.onerror = () => {
         imageContainer.style.display = "none";
         console.warn("Poppy: Cover image cannot be found.");

--- a/src/Poppy.js
+++ b/src/Poppy.js
@@ -33,6 +33,7 @@ export class Poppy {
       }
     };
     this.element = null;
+    this.init();
   }
 
   show() {


### PR DESCRIPTION
Here's a proof-of-concept for preloading the image by inserting the Poppy element upon instantiation.

* I've moved the `show()` method to `init()` which will run upon each `new Poppy()`.
* The `show()` method now un-hides the Poppy element with a CSS transition animation.
* The `close()` method animates the Poppy element out of view, then destroys the element.

I updated example in `index.html` that follows the new methods outlined above, so please take a look.
I don't know if this is the best way to implement it, so please give your feedback! Thanks!
